### PR TITLE
bump edge-tts to v5.0.1

### DIFF
--- a/custom_components/edge_tts/manifest.json
+++ b/custom_components/edge_tts/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "documentation": "https://github.com/hasscc/hass-edge-tts",
   "issue_tracker": "https://github.com/hasscc/hass-edge-tts/issues",
-  "requirements": ["edge-tts==4.0.3"],
+  "requirements": ["edge-tts==5.0.1"],
   "codeowners": [],
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
Misc changes:

- drop custom SSML support (regular customization like pitch, rate, etc still available); n/a for us because we already dropped it

Important changes:

- fix unbound local variable error if we didn't receive anything from websocket
- fix bugs for Windows related to asyncio
- fix exception for when Microsoft sends "SessionEnd" metadata type (new metadata type that Microsoft doesn't send all the time, but not handling it properly causes us to be less reliable and return no MP3)