### PR TITLE
⬆ bump edge-tts version to v6.1.0

### DIFF
--- a/custom_components/edge_tts/manifest.json
+++ b/custom_components/edge_tts/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "documentation": "https://github.com/hasscc/hass-edge-tts",
   "issue_tracker": "https://github.com/hasscc/hass-edge-tts/issues",
-  "requirements": ["edge-tts==6.0.8"],
+  "requirements": ["edge-tts==6.1.0"],
   "codeowners": [],
   "iot_class": "cloud_polling"
 }

--- a/custom_components/edge_tts/tts.py
+++ b/custom_components/edge_tts/tts.py
@@ -5,7 +5,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 
-EDGE_TTS_VERSION = '6.0.7'
+EDGE_TTS_VERSION = '6.1.0'
 try:
     import edge_tts
     if '__version__' not in dir(edge_tts) or edge_tts.__version__ != EDGE_TTS_VERSION:


### PR DESCRIPTION
6.0.9: Performance improvements and niche bug fix (fixed slight glitch with TTS reading a portion of XML character entity tag for extremely long text generation).

6.1.0: Add feature required for https://github.com/hasscc/hass-edge-tts/issues/30#issuecomment-1374472247