### PR TITLE
⬆ bump edge-tts to v6.1.14

### DIFF
--- a/custom_components/edge_tts/manifest.json
+++ b/custom_components/edge_tts/manifest.json
@@ -5,6 +5,6 @@
   "documentation": "https://github.com/hasscc/hass-edge-tts",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hasscc/hass-edge-tts/issues",
-  "requirements": ["edge-tts==6.1.12"],
+  "requirements": ["edge-tts==6.1.14"],
   "version": "0.0.1"
 }

--- a/custom_components/edge_tts/tts.py
+++ b/custom_components/edge_tts/tts.py
@@ -5,7 +5,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 
-EDGE_TTS_VERSION = '6.1.12'
+EDGE_TTS_VERSION = '6.1.14'
 try:
     import edge_tts
     if '__version__' not in dir(edge_tts) or edge_tts.__version__ != EDGE_TTS_VERSION:


### PR DESCRIPTION
⬆ bump edge-tts to v6.1.14 since 6.1.12 can not using right now.