### PR TITLE
Add de-DE-SeraphinaMultilingualNeural to supported voices

### DIFF
--- a/custom_components/edge_tts/tts.py
+++ b/custom_components/edge_tts/tts.py
@@ -95,6 +95,7 @@ SUPPORTED_VOICES = {
     'de-DE-AmalaNeural': 'de-DE',
     'de-DE-ConradNeural': 'de-DE',
     'de-DE-KatjaNeural': 'de-DE',
+    'de-DE-SeraphinaMultilingualNeural': 'de-DE',
     'de-DE-KillianNeural': 'de-DE',
     'el-GR-AthinaNeural': 'el-GR',
     'el-GR-NestorasNeural': 'el-GR',


### PR DESCRIPTION
I use this voice with other edge-tts applications too, so it would be great if added. 
I tested this change in HomeAssistant and it just worked.